### PR TITLE
CORE-6376 - add s3 publish logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,18 @@ subprojects { sub ->
                     }
                 }
             }
+            if (project.hasProperty('maven.repo.s3')) {
+                repositories {
+                    maven {
+                        url = project.findProperty('maven.repo.s3')
+                        credentials(AwsCredentials) {
+                            accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                            secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                            sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
+                        }
+                    }
+                }
+            }
         }
 
         tasks.register('install') {


### PR DESCRIPTION
Add logic which enables to to publish to a S3 repo ( to be used as a QA staging area) if maven.repo.s3 property is set .

This will be invoked from a Jenkins pipeline - to be added in a separate commit / PR