### PR TITLE
NOTICK: Only resolve these bundles against a specific kotlin-osgi-bundle version.

### DIFF
--- a/kotlin-stdlib-jdk7-osgi/build.gradle
+++ b/kotlin-stdlib-jdk7-osgi/build.gradle
@@ -30,7 +30,12 @@ def jar = tasks.named('jar', Jar) {
         bnd '''\
 Bundle-SymbolicName: net.corda.kotlin-stdlib-jdk7.osgi-bundle
 Bundle-Name: Kotlin Standard Library JDK7 classes
-Import-Package: !android.os,*
+Import-Package: \
+    kotlin.*jdk7:o;provide:=true,\
+    kotlin.io.path.*:o;provide:=true,\
+    kotlin.*;version='${range;[===,==+);${@}}',\
+    android.os.*:o;resolution:=optional,\
+    *
 '''
     }
 }

--- a/kotlin-stdlib-jdk8-osgi/build.gradle
+++ b/kotlin-stdlib-jdk8-osgi/build.gradle
@@ -24,7 +24,12 @@ tasks.named('jar', Jar) {
         bnd '''\
 Bundle-SymbolicName: net.corda.kotlin-stdlib-jdk8.osgi-bundle
 Bundle-Name: Kotlin Standard Library JDK8 classes
-Import-Package: !android.os,*
+Import-Package: \
+    kotlin.*jdk8:o;provide:=true,\
+    kotlin.jvm.optionals.*:o;provide:=true,\
+    kotlin.*;version='${range;[===,==+);${@}}',\
+    android.os.*:o;resolution:=optional,\
+    *
 '''
     }
 }


### PR DESCRIPTION
These OSGi bundles are created to supplement a _specific_ version of `kotlin-osgi-bundle`. Adjust their `Import-Package` metadata so that the framework doesn't resolve them against any later Kotlin version which may also be present.

~Edit: We need to limit the OSGi version range, but the `Import-Package` metadata for the `kotlin.random.jdk8` package is currently incorrect. I am discussing this with the Bnd developers,~
Hopefully now fixed with addition of suitable `provide:=true` flags.